### PR TITLE
Io support rebased

### DIFF
--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -48,7 +48,7 @@ namespace joint_trajectory_action
 {
 
 const double JointTrajectoryAction::WATCHD0G_PERIOD_ = 1.0;
-const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.00005;
+const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.01;
 
 JointTrajectoryAction::JointTrajectoryAction() :
   action_server_(node_, "joint_trajectory_action",

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -617,7 +617,7 @@ bool JointTrajectoryAction::withinGoalConstraints(
     if (industrial_robot_client::utils::isWithinRange(
           last_trajectory_state_->joint_names,
           last_trajectory_state_->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_))
+          traj.points[last_point].positions, goal_threshold_*2))
     {
       rtn = true;
     }
@@ -649,7 +649,7 @@ bool JointTrajectoryAction::withinGoalConstraints(const control_msgs::FollowJoin
     if (industrial_robot_client::utils::isWithinRange(
           last_trajectory_state_map_[group_number]->joint_names,
           last_trajectory_state_map_[group_number]->actual.positions, traj.joint_names,
-          traj.points[last_point].groups[3].positions, goal_threshold_))
+          traj.points[last_point].groups[3].positions, goal_threshold_*2))
     {
       rtn = true;
     }
@@ -680,7 +680,7 @@ bool JointTrajectoryAction::withinGoalConstraints(
     if (industrial_robot_client::utils::isWithinRange(
           robot_groups_[group_number].get_joint_names(),
           last_trajectory_state_map_[group_number]->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_))
+          traj.points[last_point].positions, goal_threshold_*2))
     {
       rtn = true;
     }

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -617,7 +617,7 @@ bool JointTrajectoryAction::withinGoalConstraints(
     if (industrial_robot_client::utils::isWithinRange(
           last_trajectory_state_->joint_names,
           last_trajectory_state_->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_*2))
+          traj.points[last_point].positions, goal_threshold_))
     {
       rtn = true;
     }
@@ -649,7 +649,7 @@ bool JointTrajectoryAction::withinGoalConstraints(const control_msgs::FollowJoin
     if (industrial_robot_client::utils::isWithinRange(
           last_trajectory_state_map_[group_number]->joint_names,
           last_trajectory_state_map_[group_number]->actual.positions, traj.joint_names,
-          traj.points[last_point].groups[3].positions, goal_threshold_*2))
+          traj.points[last_point].groups[3].positions, goal_threshold_))
     {
       rtn = true;
     }
@@ -680,7 +680,7 @@ bool JointTrajectoryAction::withinGoalConstraints(
     if (industrial_robot_client::utils::isWithinRange(
           robot_groups_[group_number].get_joint_names(),
           last_trajectory_state_map_[group_number]->actual.positions, traj.joint_names,
-          traj.points[last_point].positions, goal_threshold_*2))
+          traj.points[last_point].positions, goal_threshold_))
     {
       rtn = true;
     }

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_action.cpp
@@ -48,7 +48,7 @@ namespace joint_trajectory_action
 {
 
 const double JointTrajectoryAction::WATCHD0G_PERIOD_ = 1.0;
-const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.01;
+const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.00005;
 
 JointTrajectoryAction::JointTrajectoryAction() :
   action_server_(node_, "joint_trajectory_action",

--- a/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
+++ b/motoman_driver/src/industrial_robot_client/joint_trajectory_interface.cpp
@@ -98,6 +98,7 @@ bool JointTrajectoryInterface::init(SmplMsgConnection* connection)
     {
       ROS_WARN("Unable to read 'controller_joint_names' param.  Using standard 6-DOF joint names.");
     }
+    this->all_joint_names_=joint_names;
     return init(connection, joint_names);
   }
   return false;
@@ -722,6 +723,14 @@ bool JointTrajectoryInterface::is_valid(const motoman_msgs::DynamicJointTrajecto
 void JointTrajectoryInterface::jointStateCB(
   const sensor_msgs::JointStateConstPtr &msg)
 {
+  if (msg->name.size() != this->all_joint_names_.size())
+    return;
+
+  for (uint i=0; i< msg->name.size(); i++)
+    if (std::find(msg->name.begin(),msg->name.end(),this->all_joint_names_[i]) ==
+        msg->name.end())
+      return;
+  
   this->cur_joint_pos_ = *msg;
 }
 

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -466,6 +466,8 @@ bool MotomanJointTrajectoryStreamer::is_valid(const trajectory_msgs::JointTrajec
                                 traj.joint_names, traj.points[0].positions,
                                 start_pos_tol_))
   {
+    ROS_ERROR_STREAM("Current joints: "<<cur_joint_pos_);
+    ROS_ERROR_STREAM("Start joints: "<<traj.points[0]);
     ROS_ERROR_RETURN(false, "Validation failed: Trajectory doesn't start at current position.");
   }
   return true;

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -387,7 +387,7 @@ void MotomanJointTrajectoryStreamer::streamingThread()
       {
         ROS_DEBUG("Robot disconnected.  Attempting reconnect...");
         connectRetryCount = 5;
-	break;
+	      break;
       }
       this->mutex_.lock();
       
@@ -404,7 +404,7 @@ void MotomanJointTrajectoryStreamer::streamingThread()
         {
           ROS_ERROR("Aborting trajectory: Unable to parse JointTrajectoryPoint reply");
           this->state_ = TransferStates::IDLE;
-	  this->mutex_.unlock();
+	        this->mutex_.unlock();
           break;
         }
 
@@ -415,10 +415,10 @@ void MotomanJointTrajectoryStreamer::streamingThread()
           this->current_point_++;
         }
         else if (reply_status.reply_.getResult() == MotionReplyResults::BUSY) {
-	  this->mutex_.unlock();
+	        this->mutex_.unlock();
           break;  // silently retry sending this point
-	}
-        else
+      	}
+       else
         {
           ROS_ERROR_STREAM("Aborting Trajectory.  Failed to send point"
                            << " (#" << this->current_point_ << "): "

--- a/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -88,8 +88,7 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
     motion_ctrl_map_[robot_id] = motion_ctrl;
   }
 
-
-  // hacking this in here at this place
+  ROS_INFO("MotomanJointTrajectoryStreamer: starting IO services");
   io_ctrl_.init(connection);
   this->srv_read_single_io = this->node_.advertiseService("read_single_io",
       &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
@@ -115,6 +114,13 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
     node_.param("robot_id", robot_id_, 0);
 
   rtn &= motion_ctrl_.init(connection, robot_id_);
+
+  ROS_INFO("MotomanJointTrajectoryStreamer: starting IO services");
+  io_ctrl_.init(connection);
+  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
+      &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
+  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
+      &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
 
   return rtn;
 }


### PR DESCRIPTION
These are the changes we made to get to to work on the MH180.  We needed the service init and we needed to make sure that joint states could properly handle multiple /joint_state publishers even if the incoming messages didn't agree with the 6 joints controlled by this driver.
